### PR TITLE
Feat/por36 layout component desktop updates

### DIFF
--- a/src/Components/Layout.tsx
+++ b/src/Components/Layout.tsx
@@ -9,8 +9,13 @@ interface LayoutProps {
 const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <>
-      <NavBar />
-      <main className="main">{children}</main>
+      <div className="container">
+        <div className="bannerGrid" />
+        <div className="navbarGrid">
+          <NavBar />
+        </div>
+        <main className="contentGrid">{children}</main>
+      </div>
     </>
   );
 };

--- a/src/Components/Layout.tsx
+++ b/src/Components/Layout.tsx
@@ -10,11 +10,21 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   return (
     <>
       <div className="container">
-        <div className="bannerGrid" />
-        <div className="navbarGrid">
-          <NavBar />
+        <div className="bannerRow">
+          <div />
+          <h1>POLICE API</h1>
+          <div />
         </div>
-        <main className="contentGrid">{children}</main>
+        <div className="navbarRow">
+          <div />
+          <NavBar />
+          <div />
+        </div>
+        <main className="contentRow">
+          <div />
+          {children}
+          <div />
+        </main>
       </div>
     </>
   );

--- a/src/Components/NavBar.tsx
+++ b/src/Components/NavBar.tsx
@@ -5,14 +5,16 @@ import "../Styling/components/navbar.scss";
 const NavBar: React.FC = () => {
   return (
     <div className="navBar">
-      <Button
-        text={"Home"}
-        onClick={() => console.log("Home button clicked")}
-      />
-      <Button
-        text={"Police API"}
-        onClick={() => console.log("Police API button clicked")}
-      />
+      <div className="marginLeft">
+        <Button
+          text={"Home"}
+          onClick={() => console.log("Home button clicked")}
+        />
+        <Button
+          text={"Police API"}
+          onClick={() => console.log("Police API button clicked")}
+        />
+      </div>
     </div>
   );
 };

--- a/src/Styling/components/navbar.scss
+++ b/src/Styling/components/navbar.scss
@@ -9,8 +9,12 @@ $background-color: #282c34;
   align-items: center;
   height: 75px;
   background-color: #282c34;
-  margin-bottom: 5%;
-  padding: 10px;
+  // margin-bottom: 5%;
+  // padding: 10px;
   border-bottom: 2px solid #7c8ba8;
   gap: 50px;
+}
+
+.marginLeft {
+  margin-left: 5%;
 }

--- a/src/Styling/layout/layout.scss
+++ b/src/Styling/layout/layout.scss
@@ -15,15 +15,28 @@ body {
   background-color: #282c34;
 }
 
-.main {
-  padding: 1.5rem;
-  max-width: 90%; //sets max-width of screen
-  margin: 0 auto; //centers content
+p {
+  word-wrap: break-word; //wraps long pieces of text
 }
 
-p {
-  max-width: 100%; //inherits width from parent
-  word-wrap: break-word; //wraps long pieces of text
+.container {
+  display: grid;
+  grid-template-columns: 1fr 5fr 1fr;
+  grid-template-rows: 1fr 1fr 5fr;
+}
+
+.bannerGrid {
+  background-color: #0f1013;
+  grid-column: 1 / 4;
+}
+
+.navbarGrid {
+  background-color: #505666;
+  grid-column: 1 / 4;
+}
+
+.contentGrid {
+  grid-column: 2 / 3;
 }
 
 .centre {

--- a/src/Styling/layout/layout.scss
+++ b/src/Styling/layout/layout.scss
@@ -7,36 +7,34 @@ body {
   color: $primary-color;
 }
 
-html,
-body {
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  background-color: #282c34;
-}
-
 p {
   word-wrap: break-word; //wraps long pieces of text
 }
 
+.red {
+  background-color: red;
+}
+
 .container {
   display: grid;
-  grid-template-columns: 1fr 5fr 1fr;
   grid-template-rows: 1fr 1fr 5fr;
 }
 
-.bannerGrid {
+.bannerRow {
   background-color: #0f1013;
-  grid-column: 1 / 4;
+  display: grid;
+  grid-template-columns: 1fr 5fr 1fr;
 }
 
-.navbarGrid {
+.navbarRow {
   background-color: #505666;
-  grid-column: 1 / 4;
+  display: grid;
+  grid-template-columns: 1fr 5fr 1fr;
 }
 
-.contentGrid {
-  grid-column: 2 / 3;
+.contentRow {
+  display: grid;
+  grid-template-columns: 1fr 5fr 1fr;
 }
 
 .centre {
@@ -45,3 +43,10 @@ p {
   justify-content: center;
   align-items: center;
 }
+
+// .bannerGrid,
+// .contentGrid,
+// .navbarGrid {
+//   display: grid;
+//   grid-template-columns: 1fr 5fr 1fr;
+// }


### PR DESCRIPTION
Create grid layout based no designs 

Don’t worry about components or positioning of content - just get the grid layout

![image](https://github.com/user-attachments/assets/abaf27ce-01d8-4eb9-bca9-0ae7972ac7d1)
