### PR TITLE
Feat/por91 update related item unit tests

### DIFF
--- a/src/Components/Button/Button.spec.tsx
+++ b/src/Components/Button/Button.spec.tsx
@@ -5,7 +5,7 @@ import React from "react";
 interface Props {
   text: string;
   variant: "primary" | "secondary";
-  onClick: () => void;
+  onClick: typeof jest.fn;
   dataTestId?: string;
 }
 
@@ -28,7 +28,7 @@ const secondaryValidProps: Props = {
 const invalidProps: Props = {
   text: "",
   variant: "primary",
-  onClick: () => console.log("clicked"),
+  onClick: handleClick,
 };
 
 const renderComponent = (props: Props) => render(<Button {...props} />);
@@ -132,7 +132,7 @@ describe("Button tests", () => {
 
   describe("Invalid props where text is an empty string tests", () => {
     const datatestid = "button";
-    it("SHOULD render the button with 'Click' WHEN text prop is an empty string", async () => {
+    it("SHOULD render the button with 'No text given' WHEN text prop is an empty string", async () => {
       //arrange
       const { getByTestId } = renderComponent(invalidProps);
 

--- a/src/Components/RelatedContentItem/RelatedContentItem.spec.tsx
+++ b/src/Components/RelatedContentItem/RelatedContentItem.spec.tsx
@@ -2,28 +2,62 @@ import { render } from "@testing-library/react";
 import { RelatedContentItem } from "./RelatedContentItem";
 import React from "react";
 
-const defaultProps = {
+interface RelatedContentItemProps {
+  imageSource: string;
+  title: string;
+  href: string;
+}
+
+const validProps = {
   imageSource: "/assets/internal-police-reports.jpg",
   title: "Test Title",
-  href: "",
+  href: "https://www.police.uk/pu/performance/",
 };
 
-const renderRelatedContentItem = (props = {}) =>
-  render(<RelatedContentItem {...defaultProps} {...props} />);
+const emptyTitleProps = {
+  imageSource: "/assets/internal-police-reports.jpg",
+  title: "   ",
+  href: "https://www.police.uk/pu/performance/",
+};
+
+const emptyImageSourceProps = {
+  imageSource: "   ",
+  title: "Test Title",
+  href: "https://www.police.uk/pu/performance/",
+};
+
+const emptyHrefProps = {
+  imageSource: "/assets/internal-police-reports.jpg",
+  title: "Test Title",
+  href: "   ",
+};
+
+const renderRelatedContentItem = (props: RelatedContentItemProps) =>
+  render(<RelatedContentItem {...props} />);
 
 describe("Related Content Item tests", () => {
   const componentPrefix = "related-content-";
 
   describe("Valid props", () => {
     it("SHOULD render a title WHEN title is valid", async () => {
-      const { getByTestId } = renderRelatedContentItem();
+      //arrange
+      const { getByTestId } = renderRelatedContentItem(validProps);
+
+      //act
       const title = getByTestId(`${componentPrefix}title`);
+
+      //assert
       expect(title.textContent).toBe("Test Title");
     });
 
     it("SHOULD render correct image WHEN image is valid", async () => {
-      const { getByTestId } = renderRelatedContentItem();
+      //arrange
+      const { getByTestId } = renderRelatedContentItem(validProps);
+
+      //act
       const image = getByTestId(`${componentPrefix}image`);
+
+      //assert
       expect(image).toBeInTheDocument();
       expect(image).toHaveAttribute(
         "src",
@@ -31,14 +65,48 @@ describe("Related Content Item tests", () => {
       );
     });
 
-    it("SHOULD render a link WHEN href is valid", async () => {
-      const { getByTestId } = renderRelatedContentItem();
+    it("SHOULD render correct link WHEN href is valid", async () => {
+      //arrange
+      const { getByTestId } = renderRelatedContentItem(validProps);
+
+      //act
       const link = getByTestId(`${componentPrefix}link`);
+
+      //assert
       expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute(
+        "href",
+        "https://www.police.uk/pu/performance/"
+      );
+    });
+  });
+
+  describe("Invalid props", () => {
+    it("SHOULD render null WHEN title is an empty string", async () => {
+      //arrange
+      const { container } = renderRelatedContentItem(emptyTitleProps);
+      //act
+
+      //assert
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("SHOULD render null WHEN imageSource is an empty string", async () => {
+      //arrange
+      const { container } = renderRelatedContentItem(emptyImageSourceProps);
+      //act
+
+      //assert
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("SHOULD render null WHEN href is an empty string", async () => {
+      //arrange
+      const { container } = renderRelatedContentItem(emptyHrefProps);
+      //act
+
+      //assert
+      expect(container.firstChild).toBeNull();
     });
   });
 });
-
-//could maybe have ternary for if no href don't render anything
-//maybe a default for the title
-//image maybe ioptional - just hide it fi no source available - or a default image

--- a/src/Components/RelatedContentItem/RelatedContentItem.tsx
+++ b/src/Components/RelatedContentItem/RelatedContentItem.tsx
@@ -12,7 +12,13 @@ const RelatedContentItem: React.FC<RelatedContentItemProps> = ({
   title,
   href,
 }) => {
-  return (
+  const safeImageSource = imageSource?.trim() || false;
+
+  const safeTitle = title?.trim() || false;
+
+  const safeHref = href?.trim() || false;
+
+  return safeImageSource && safeTitle && safeHref ? (
     <div
       className="relatedContentItemContainer"
       data-testid="related-content-item-container"
@@ -20,22 +26,24 @@ const RelatedContentItem: React.FC<RelatedContentItemProps> = ({
       <a
         className="linkContainer"
         data-testid="related-content-link"
-        href={href}
+        href={safeHref}
+        rel="noopener noreferrer"
+        target="_blank"
       >
         <img
           className="relatedContentItemImage"
-          src={imageSource}
+          src={safeImageSource}
           data-testid="related-content-image"
         />
         <div
           className="relatedContentItemTitle"
           data-testid="related-content-title"
         >
-          {title}
+          {safeTitle}
         </div>
       </a>
     </div>
-  );
+  ) : null;
 };
 
 export { RelatedContentItem };

--- a/src/Pages/Home.tsx
+++ b/src/Pages/Home.tsx
@@ -62,12 +62,12 @@ const Home: React.FC = () => {
             process.env.PUBLIC_URL + "/assets/internal-police-reports.jpg"
           }
           title="Internal police reports"
-          href=""
+          href="https://www.police.uk/pu/performance/"
         />
         <RelatedContentItem
           imageSource={process.env.PUBLIC_URL + "/assets/local-community.jpg"}
           title="Local community initiatives"
-          href=""
+          href="https://www.met.police.uk/advice/advice-and-information/wsi/watch-schemes-initiatives/"
         />
       </div>
     </>


### PR DESCRIPTION
- Update related content item component to handle empty strings for props 
- Will not render component if any of the props are empty strings 
- update hrefs where component is used 
- Update unit tests to check these new changes